### PR TITLE
Fix Upstash env handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Example Upstash configuration
+# Copy this file to `.env` and provide your own credentials.
+KV_REST_API_URL=https://liberal-rhino-35659.upstash.io
+KV_REST_API_TOKEN=replace-with-your-token

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ dist-ssr
 *.sln
 *.sw?
 .env.local
+.env

--- a/readme.txt
+++ b/readme.txt
@@ -1,0 +1,2 @@
+This project uses environment variables for Upstash KV.
+Copy `.env.example` to `.env` and provide your REST API token before running the application.


### PR DESCRIPTION
## Summary
- delete `.env` to remove credentials from source control
- ignore `.env`
- add `.env.example` with placeholder token
- document env setup in `readme.txt`

## Testing
- `npm ci`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684359c7b594833384952d836bb70ecf