### PR TITLE
Fix Upstash API runtime

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,2 +1,2 @@
 This project uses environment variables for Upstash KV.
-Copy `.env.example` to `.env` and provide your REST API token before running the application.
+Copy `.env.example` to `.env.local` and provide your REST API credentials before running the application.

--- a/src/.env.example
+++ b/src/.env.example
@@ -1,4 +1,4 @@
 # Copy this file to `.env.local` so Next.js can load these values
 # Fill in your Upstash URL and token
-KV_REST_API_URL= https://liberal-rhino-35659.upstash.io
-KV_REST_API_TOKEN= AYtLAAIjcDE1ODM2ODI3MzAwN2I0Y2IwOGQ5N2NmZTQxM2FkMjJkNHAxMA
+KV_REST_API_URL=https://liberal-rhino-35659.upstash.io
+KV_REST_API_TOKEN=AYtLAAIjcDE1ODM2ODI3MzAwN2I0Y2IwOGQ5N2NmZTQxM2FkMjJkNHAxMA

--- a/src/lib/upstash.ts
+++ b/src/lib/upstash.ts
@@ -1,6 +1,10 @@
 export const BASE_URL = process.env.KV_REST_API_URL;
 export const TOKEN = process.env.KV_REST_API_TOKEN;
 
+import https from 'node:https';
+
+const agent = new https.Agent({ family: 4 });
+
 export async function callUpstash(body: unknown[]): Promise<Response> {
   if (!BASE_URL || !TOKEN) {
     throw new Error('Upstash URL or token missing');
@@ -12,8 +16,11 @@ export async function callUpstash(body: unknown[]): Promise<Response> {
         Authorization: `Bearer ${TOKEN}`,
         'Content-Type': 'application/json',
       },
+      // Prefer IPv4 to avoid potential IPv6 routing issues
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ...(agent ? { agent } : {} as any),
       body: JSON.stringify(body),
-    });
+    } as RequestInit);
   } catch (error) {
     console.error('[lib/upstash] fetch failed:', error);
     const message =

--- a/src/lib/upstash.ts
+++ b/src/lib/upstash.ts
@@ -1,11 +1,14 @@
-export const BASE_URL = process.env.KV_REST_API_URL;
-export const TOKEN = process.env.KV_REST_API_TOKEN;
-
 import https from 'node:https';
+
+// Re-create these for each call so values from the environment are read at runtime
+// rather than during module initialization.
+
 
 const agent = new https.Agent({ family: 4 });
 
 export async function callUpstash(body: unknown[]): Promise<Response> {
+  const BASE_URL = process.env.KV_REST_API_URL;
+  const TOKEN = process.env.KV_REST_API_TOKEN;
   if (!BASE_URL || !TOKEN) {
     throw new Error('Upstash URL or token missing');
   }

--- a/src/lib/upstash.ts
+++ b/src/lib/upstash.ts
@@ -20,8 +20,7 @@ export async function callUpstash(body: unknown[]): Promise<Response> {
         'Content-Type': 'application/json',
       },
       // Prefer IPv4 to avoid potential IPv6 routing issues
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      ...(agent ? { agent } : {} as any),
+      dispatcher: agent,
       body: JSON.stringify(body),
     } as RequestInit);
   } catch (error) {

--- a/src/lib/upstash.ts
+++ b/src/lib/upstash.ts
@@ -1,0 +1,17 @@
+export const BASE_URL = process.env.KV_REST_API_URL;
+export const TOKEN = process.env.KV_REST_API_TOKEN;
+
+export async function callUpstash(body: unknown[]): Promise<Response> {
+  if (!BASE_URL || !TOKEN) {
+    throw new Error('Upstash URL or token missing');
+  }
+  return fetch(BASE_URL, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${TOKEN}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+}
+

--- a/src/lib/upstash.ts
+++ b/src/lib/upstash.ts
@@ -5,13 +5,21 @@ export async function callUpstash(body: unknown[]): Promise<Response> {
   if (!BASE_URL || !TOKEN) {
     throw new Error('Upstash URL or token missing');
   }
-  return fetch(BASE_URL, {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${TOKEN}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(body),
-  });
+  try {
+    return await fetch(BASE_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? `Network request failed: ${error.message}`
+        : 'Network request failed';
+    throw new Error(message);
+  }
 }
 

--- a/src/lib/upstash.ts
+++ b/src/lib/upstash.ts
@@ -15,11 +15,12 @@ export async function callUpstash(body: unknown[]): Promise<Response> {
       body: JSON.stringify(body),
     });
   } catch (error) {
+    console.error('[lib/upstash] fetch failed:', error);
     const message =
       error instanceof Error
         ? `Network request failed: ${error.message}`
         : 'Network request failed';
-    throw new Error(message);
+    throw new Error(message, { cause: error instanceof Error ? error : undefined });
   }
 }
 

--- a/src/pages/api/kv/del.ts
+++ b/src/pages/api/kv/del.ts
@@ -1,4 +1,3 @@
-// src/pages/api/kv/del.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { callUpstash } from '../../../lib/upstash';
 
@@ -10,7 +9,7 @@ export const config = {
 type Data = {
   result?: number;
   error?: string;
-  details?: string; // Keep details for structured error
+  details?: string;
 };
 
 export default async function handler(

--- a/src/pages/api/kv/del.ts
+++ b/src/pages/api/kv/del.ts
@@ -1,6 +1,10 @@
 // src/pages/api/kv/del.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
 
+export const config = {
+  runtime: 'nodejs',
+};
+
 const BASE_URL = process.env.KV_REST_API_URL;
 const TOKEN = process.env.KV_REST_API_TOKEN;
 

--- a/src/pages/api/kv/get.ts
+++ b/src/pages/api/kv/get.ts
@@ -1,12 +1,11 @@
 // src/pages/api/kv/get.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { callUpstash } from '../../../lib/upstash';
 
 export const config = {
   runtime: 'nodejs',
 };
 
-const BASE_URL = process.env.KV_REST_API_URL;
-const TOKEN = process.env.KV_REST_API_TOKEN;
 
 type Data = {
   result?: string | null;
@@ -23,10 +22,6 @@ export default async function handler(
     return res.status(405).end(`Method ${req.method} Not Allowed`);
   }
 
-  if (!BASE_URL || !TOKEN) {
-    console.error("[API /kv/get] Upstash URL or Token is missing from server environment variables!");
-    return res.status(500).json({ error: 'Server configuration error' });
-  }
 
   const { key } = req.query;
 
@@ -36,12 +31,7 @@ export default async function handler(
 
   try {
     console.log(`[API /kv/get] Attempting to get key: ${key}`);
-    const upstashResponse = await fetch(`${BASE_URL}/get/${key}`, {
-      method: 'GET',
-      headers: {
-        Authorization: `Bearer ${TOKEN}`,
-      },
-    });
+    const upstashResponse = await callUpstash(['GET', key]);
 
     if (!upstashResponse.ok) {
       const errorText = await upstashResponse.text();
@@ -49,7 +39,7 @@ export default async function handler(
       try {
         const upstashError = JSON.parse(errorText);
         return res.status(upstashResponse.status).json({ error: `Upstash error: ${upstashError.error || errorText}` });
-      } catch (_e) { // Changed 'e' to '_e'
+      } catch (_e) {
         return res.status(upstashResponse.status).json({ error: `Upstash error: ${errorText}` });
       }
     }
@@ -58,7 +48,7 @@ export default async function handler(
     console.log(`[API /kv/get] Successfully got key: ${key}. Value:`, data.result ? String(data.result).substring(0,50) + '...' : null);
     return res.status(200).json({ result: data.result ?? null });
 
-  } catch (error: unknown) { // Changed 'error: any' to 'error: unknown'
+  } catch (error: unknown) {
     console.error(`[API /kv/get] Internal error getting key ${key}:`, error);
     const message = error instanceof Error ? error.message : 'Failed to get value from KV store';
     return res.status(500).json({ error: message, details: String(error) });

--- a/src/pages/api/kv/get.ts
+++ b/src/pages/api/kv/get.ts
@@ -1,6 +1,10 @@
 // src/pages/api/kv/get.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
 
+export const config = {
+  runtime: 'nodejs',
+};
+
 const BASE_URL = process.env.KV_REST_API_URL;
 const TOKEN = process.env.KV_REST_API_TOKEN;
 

--- a/src/pages/api/kv/get.ts
+++ b/src/pages/api/kv/get.ts
@@ -1,4 +1,3 @@
-// src/pages/api/kv/get.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { callUpstash } from '../../../lib/upstash';
 
@@ -10,7 +9,7 @@ export const config = {
 type Data = {
   result?: string | null;
   error?: string;
-  details?: string; // Keep details for structured error
+  details?: string;
 };
 
 export default async function handler(

--- a/src/pages/api/kv/set.ts
+++ b/src/pages/api/kv/set.ts
@@ -1,12 +1,15 @@
-// src/pages/api/kv/set.ts
 import type { NextApiRequest, NextApiResponse } from 'next';
+
+export const config = {
+  runtime: 'nodejs',
+};
 
 const BASE_URL = process.env.KV_REST_API_URL;
 const TOKEN = process.env.KV_REST_API_TOKEN;
 
 export default async function handler(
   req: NextApiRequest,
-  res: NextApiResponse // Type for res.json() will be inferred or can be more specific
+  res: NextApiResponse
 ) {
   if (req.method !== 'POST') {
     res.setHeader('Allow', ['POST']);
@@ -44,7 +47,7 @@ export default async function handler(
     console.log(`[API /kv/set] Successfully set key: ${key}. Upstash response:`, data);
     return res.status(200).json(data);
 
-  } catch (error: unknown) { // Changed 'error: any' to 'error: unknown'
+  } catch (error: unknown) {
     console.error(`[API /kv/set] Error setting key ${key}:`, error);
     const message = error instanceof Error ? error.message : 'Failed to set value in KV store';
     return res.status(500).json({ error: message, details: String(error) });

--- a/src/pages/api/kv/set.ts
+++ b/src/pages/api/kv/set.ts
@@ -1,11 +1,10 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { callUpstash } from '../../../lib/upstash';
 
 export const config = {
   runtime: 'nodejs',
 };
 
-const BASE_URL = process.env.KV_REST_API_URL;
-const TOKEN = process.env.KV_REST_API_TOKEN;
 
 export default async function handler(
   req: NextApiRequest,
@@ -16,10 +15,6 @@ export default async function handler(
     return res.status(405).end(`Method ${req.method} Not Allowed`);
   }
 
-  if (!BASE_URL || !TOKEN) {
-    console.error("[API /kv/set] Upstash URL or Token is missing from server environment variables!");
-    return res.status(500).json({ error: 'Server configuration error' });
-  }
 
   const { key, value } = req.body;
 
@@ -29,13 +24,7 @@ export default async function handler(
 
   try {
     console.log(`[API /kv/set] Setting key: ${key}`);
-    const upstashResponse = await fetch(`${BASE_URL}/set/${key}`, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${TOKEN}`,
-      },
-      body: value,
-    });
+    const upstashResponse = await callUpstash(['SET', key, value]);
 
     if (!upstashResponse.ok) {
       const errorText = await upstashResponse.text();

--- a/src/pages/api/kv/set.ts
+++ b/src/pages/api/kv/set.ts
@@ -53,3 +53,4 @@ export default async function handler(
     return res.status(500).json({ error: message, details: String(error) });
   }
 }
+


### PR DESCRIPTION
## Summary
- ensure `src/pages/api/kv/set.ts` uses Node.js runtime instead of the edge runtime
- drop stray comments from the set handler

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6848f1d51e0c8333a7745ab0b624f765