### PR TITLE
Fix Upstash API runtime

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "next": "^15.3.2",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "undici": "^5.26.2",
         "zustand": "^4.5.1"
       },
       "devDependencies": {
@@ -209,6 +210,15 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@humanfs/core": {
@@ -6236,6 +6246,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "5.26.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.26.2.tgz",
+      "integrity": "sha512-a4PDLQgLTPHVzOK+x3F79/M4GtyYPl+aX9AAK7aQxpwxDwCqkeZCScy7Gk5kWT3JtdFq1uhO3uZJdLtHI4dK9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "next": "^15.3.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "undici": "^5.26.2",
     "zustand": "^4.5.1"
   },
   "devDependencies": {

--- a/readme.txt
+++ b/readme.txt
@@ -1,2 +1,2 @@
 This project uses environment variables for Upstash KV.
-Copy `.env.example` to `.env` and provide your REST API token before running the application.
+Copy `.env.example` to `.env.local` and provide your REST API credentials before running the application.

--- a/readme.txt
+++ b/readme.txt
@@ -1,2 +1,2 @@
 This project uses environment variables for Upstash KV.
-Copy `.env.example` to `.env.local` and provide your REST API credentials before running the application.
+Copy `.env.example` to `.env.local` and provide your REST API credentials before running the application. Either `KV_REST_API_URL/TOKEN` or the `UPSTASH_REDIS_REST_URL/TOKEN` pair will work.

--- a/src/.env.example
+++ b/src/.env.example
@@ -2,3 +2,6 @@
 # Fill in your Upstash URL and token
 KV_REST_API_URL=https://liberal-rhino-35659.upstash.io
 KV_REST_API_TOKEN=AYtLAAIjcDE1ODM2ODI3MzAwN2I0Y2IwOGQ5N2NmZTQxM2FkMjJkNHAxMA
+# Or use these environment variable names if preferred
+# UPSTASH_REDIS_REST_URL=
+# UPSTASH_REDIS_REST_TOKEN=

--- a/src/.env.example
+++ b/src/.env.example
@@ -1,4 +1,4 @@
 # Copy this file to `.env.local` so Next.js can load these values
 # Fill in your Upstash URL and token
-KV_REST_API_URL= https://liberal-rhino-35659.upstash.io
-KV_REST_API_TOKEN= AYtLAAIjcDE1ODM2ODI3MzAwN2I0Y2IwOGQ5N2NmZTQxM2FkMjJkNHAxMA
+KV_REST_API_URL=https://liberal-rhino-35659.upstash.io
+KV_REST_API_TOKEN=AYtLAAIjcDE1ODM2ODI3MzAwN2I0Y2IwOGQ5N2NmZTQxM2FkMjJkNHAxMA

--- a/src/lib/upstash.ts
+++ b/src/lib/upstash.ts
@@ -1,0 +1,35 @@
+import https from 'node:https';
+
+// Re-create these for each call so values from the environment are read at runtime
+// rather than during module initialization.
+
+
+const agent = new https.Agent({ family: 4 });
+
+export async function callUpstash(body: unknown[]): Promise<Response> {
+  const BASE_URL = process.env.KV_REST_API_URL;
+  const TOKEN = process.env.KV_REST_API_TOKEN;
+  if (!BASE_URL || !TOKEN) {
+    throw new Error('Upstash URL or token missing');
+  }
+  try {
+    return await fetch(BASE_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+      // Prefer IPv4 to avoid potential IPv6 routing issues
+      dispatcher: agent,
+      body: JSON.stringify(body),
+    } as RequestInit);
+  } catch (error) {
+    console.error('[lib/upstash] fetch failed:', error);
+    const message =
+      error instanceof Error
+        ? `Network request failed: ${error.message}`
+        : 'Network request failed';
+    throw new Error(message, { cause: error instanceof Error ? error : undefined });
+  }
+}
+

--- a/src/lib/upstash.ts
+++ b/src/lib/upstash.ts
@@ -7,8 +7,10 @@ import https from 'node:https';
 const agent = new https.Agent({ family: 4 });
 
 export async function callUpstash(body: unknown[]): Promise<Response> {
-  const BASE_URL = process.env.KV_REST_API_URL;
-  const TOKEN = process.env.KV_REST_API_TOKEN;
+  const BASE_URL =
+    process.env.KV_REST_API_URL || process.env.UPSTASH_REDIS_REST_URL;
+  const TOKEN =
+    process.env.KV_REST_API_TOKEN || process.env.UPSTASH_REDIS_REST_TOKEN;
   if (!BASE_URL || !TOKEN) {
     throw new Error('Upstash URL or token missing');
   }


### PR DESCRIPTION
## Summary
- ensure `src/pages/api/kv` endpoints use Node.js runtime instead of the edge runtime
- refactor KV handlers to share a small Upstash helper
- improve Upstash error handling
- read Upstash environment variables inside the helper at runtime
- prefer IPv4 connections using a dispatcher in the helper
- fix spaces in env example and clarify README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6848f1d51e0c8333a7745ab0b624f765