### PR TITLE
Fix scoreboard loop

### DIFF
--- a/src/components/JudgeView.tsx
+++ b/src/components/JudgeView.tsx
@@ -77,7 +77,6 @@ const JudgeView: React.FC = () => {
         judge={roomData.judge}
         onClose={() => {
           setShowScoreboard(false);
-          winnerRef.current = null;      // Reset winner tracking after manual close
           soundPlayedRef.current = false; // Reset sound flag to allow future plays
         }}
       />

--- a/src/components/PlayerView.tsx
+++ b/src/components/PlayerView.tsx
@@ -80,7 +80,6 @@ const PlayerView: React.FC = () => {
         judge={roomData.judge}
         onClose={() => {
           setShowScoreboard(false);
-          winnerRef.current = null;      // Reset winner tracking after manual close
           soundPlayedRef.current = false; // Reset sound flag to allow future plays
         }}
       />


### PR DESCRIPTION
## Summary
- prevent scoreboard re-opening on close by not clearing `winnerRef`

## Testing
- `npx eslint . --max-warnings=0`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685f550a641883338d7150fea2162406